### PR TITLE
remove race condition on unlockKeyrings output

### DIFF
--- a/index.js
+++ b/index.js
@@ -446,8 +446,8 @@ class KeyringController extends EventEmitter {
     .then((vault) => {
       this.password = password
       this.memStore.updateState({ isUnlocked: true })
-      vault.forEach(this.restoreKeyring.bind(this))
-      return this.keyrings
+      return Promise.all(vault.map(this.restoreKeyring.bind(this)))
+      .then(() => this.keyrings)
     })
   }
 

--- a/test/index.js
+++ b/test/index.js
@@ -161,4 +161,19 @@ describe('KeyringController', function () {
       assert.notEqual(result, tooBigOutput, 'not that bad estimate')
     })
   })
+
+  describe('#unlockKeyrings', function () {
+    it('returns the list of keyrings', function (done) {
+      keyringController.setLocked()
+      keyringController.unlockKeyrings(password)
+        .then(function (keyrings) {
+          assert.notStrictEqual(keyrings.length, 0)
+          keyrings.forEach(keyring => {
+            assert.strictEqual(keyring.wallets.length, 1)
+          })
+          done()
+        })
+        .catch(done)
+    })
+  })
 })


### PR DESCRIPTION
keyrings weren't available at the return of promise of unlockKeyrings, making in difficult to use right after its execution (ex: submitPassword(xxx).then(...) was not possible.